### PR TITLE
Update reusable-snippets.mdx

### DIFF
--- a/essentials/reusable-snippets.mdx
+++ b/essentials/reusable-snippets.mdx
@@ -47,7 +47,7 @@ import MySnippet from '/snippets/path/to/my-snippet.mdx';
 
 ## Header
 
-Lorem impsum dolor sit amet.
+Lorem ipsum dolor sit amet.
 
 <MySnippet word="bananas" />
 ```


### PR DESCRIPTION

<img width="270" alt="Снимок экрана 2024-10-23 в 19 28 54" src="https://github.com/user-attachments/assets/f1e5e02f-0c7d-4f98-8cdd-f8dc3d6063b8">

"Lorem impsum" should be "Lorem **ipsum**":
Corrected: "Lorem ipsum dolor sit amet."